### PR TITLE
일정 추가 버튼을 TodoList에서 Calendar로 이동 및 코드 정리

### DIFF
--- a/index.html
+++ b/index.html
@@ -15,15 +15,15 @@
       html, body {
         margin: 0;
         padding: 0;
-        overflow: hidden;
         width: 100%;
         height: 100%;
+        overflow: auto;
       }
 
       #root {
         width: 100%;
-        height: 100%;
-        overflow: hidden;
+        min-height: 100%;
+        overflow: visible;
       }
     </style>
   </head>

--- a/src/domains/MeetingDetailsPage/components/TodoScheduleTab.jsx
+++ b/src/domains/MeetingDetailsPage/components/TodoScheduleTab.jsx
@@ -30,7 +30,9 @@ import {
   CircularProgress,
   Alert,
   Snackbar,
-  Tooltip
+  Tooltip,
+  Menu,
+  ListItemButton
 } from '@mui/material';
 import DeleteIcon from '@mui/icons-material/Delete';
 import EditIcon from '@mui/icons-material/Edit';
@@ -41,7 +43,7 @@ import AssignmentIcon from '@mui/icons-material/Assignment';
 import ContentCopyIcon from '@mui/icons-material/ContentCopy';
 import NoteAddIcon from '@mui/icons-material/NoteAdd';
 import PersonAddAltIcon from '@mui/icons-material/PersonAddAlt';
-import { getMeetingDetails, updateTodo, addTodo, deleteTodo } from '../../../apis/fakeApi';
+import { getMeetingDetails, deleteTodo } from '../../../apis/fakeApi';
 
 /**
  * 할 일 항목 컴포넌트
@@ -142,6 +144,10 @@ const DateSection = ({ date, todos, onEditTodo, onDeleteTodo, onAddDateToMySched
     setExpanded(!expanded);
   };
 
+  const handleAddToSchedule = (date, type) => {
+    onAddDateToMySchedule(date, todos, type);
+  };
+
   return (
     <Accordion 
       expanded={expanded} 
@@ -160,7 +166,7 @@ const DateSection = ({ date, todos, onEditTodo, onDeleteTodo, onAddDateToMySched
     >
       <AccordionSummary
         expandIcon={
-          <IconButton size="small">
+          <IconButton size="small" component="span">
             <ExpandMoreIcon />
           </IconButton>
         }
@@ -168,10 +174,7 @@ const DateSection = ({ date, todos, onEditTodo, onDeleteTodo, onAddDateToMySched
       >
         <DateSectionHeader 
           date={date} 
-          onAddToSchedule={(e) => {
-            e.stopPropagation(); 
-            onAddDateToMySchedule(date, todos);
-          }} 
+          onAddToSchedule={handleAddToSchedule}
         />
       </AccordionSummary>
       <AccordionDetails sx={{ p: 0 }}>
@@ -195,18 +198,55 @@ const DateSection = ({ date, todos, onEditTodo, onDeleteTodo, onAddDateToMySched
 /**
  * 날짜 섹션 헤더 컴포넌트
  */
-const DateSectionHeader = ({ date, onAddToSchedule }) => (
-  <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
-    <Typography variant="h6">
-      일 하기({formatDate(date)})
-    </Typography>
-    <Tooltip title="내 일정에 추가">
-      <IconButton size="small" onClick={onAddToSchedule}>
-        <NoteAddIcon fontSize="small" />
-      </IconButton>
-    </Tooltip>
-  </Box>
-);
+const DateSectionHeader = ({ date, onAddToSchedule }) => {
+  const [anchorEl, setAnchorEl] = useState(null);
+  const open = Boolean(anchorEl);
+  
+  const handleMenuOpen = (event) => {
+    event.stopPropagation();
+    setAnchorEl(event.currentTarget);
+  };
+  
+  const handleMenuClose = (event) => {
+    if (event) event.stopPropagation();
+    setAnchorEl(null);
+  };
+  
+  const handleScheduleAdd = (type) => (event) => {
+    event.stopPropagation();
+    onAddToSchedule(date, type);
+    handleMenuClose();
+  };
+  
+  return (
+    <Box sx={{ display: 'flex', alignItems: 'center', justifyContent: 'space-between', width: '100%' }}>
+      <Typography variant="h6">
+        일 하기({formatDate(date)})
+      </Typography>
+      <Tooltip title="내 일정에 추가">
+        <IconButton 
+          size="small" 
+          component="span" 
+          onClick={handleMenuOpen}
+        >
+          <NoteAddIcon fontSize="small" />
+        </IconButton>
+      </Tooltip>
+      <Menu
+        anchorEl={anchorEl}
+        open={open}
+        onClose={handleMenuClose}
+        onClick={(e) => e.stopPropagation()}
+      >
+        <MenuItem onClick={handleScheduleAdd('회사')}>회사 일정으로 추가</MenuItem>
+        <MenuItem onClick={handleScheduleAdd('팀')}>팀 일정으로 추가</MenuItem>
+        <MenuItem onClick={handleScheduleAdd('개인')}>개인 일정으로 추가</MenuItem>
+        <Divider />
+        <MenuItem onClick={handleScheduleAdd('전체')}>모든 일정으로 추가</MenuItem>
+      </Menu>
+    </Box>
+  );
+};
 
 /**
  * ToDo 및 일정 탭 컴포넌트
@@ -216,29 +256,11 @@ const TodoScheduleTab = ({ meetingId = 1 }) => {
   const [error, setError] = useState(null);
   const [todos, setTodos] = useState([]);
 
-  const [todoDialogOpen, setTodoDialogOpen] = useState(false);
-  const [currentTodo, setCurrentTodo] = useState({ 
-    text: '', 
-    completed: false, 
-    assignee: '', 
-    dueDate: '' 
-  });
-  const [editingTodoId, setEditingTodoId] = useState(null);
-
   const [snackbar, setSnackbar] = useState({
     open: false,
     message: '',
     severity: 'success'
   });
-
-
-  const teamMembers = [
-    '장준영 부장',
-    '김범수 과장',
-    '이지원 대리',
-    '박민준 사원',
-    '최서연 과장'
-  ];
 
   // 회의 데이터 불러오기
   useEffect(() => {
@@ -275,68 +297,25 @@ const TodoScheduleTab = ({ meetingId = 1 }) => {
   /**
    * 할 일 편집 핸들러
    */
-  const handleEditTodo = (todo) => {
-    setCurrentTodo({ ...todo });
-    setEditingTodoId(todo.id);
-    setTodoDialogOpen(true);
-  };
-
-  /**
-   * 새 할 일 추가 핸들러
-   */
-  const handleAddTodo = () => {
-    const today = new Date();
-    const formattedDate = `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`;
-    
-    setCurrentTodo({ 
-      text: '', 
-      completed: false, 
-      assignee: '', 
-      dueDate: formattedDate
-    });
-    setEditingTodoId(null);
-    setTodoDialogOpen(true);
+  const handleEditTodo = () => {
+    // 편집 기능이 제거되었으므로 알림만 표시
+    showSnackbar('편집 기능이 비활성화되었습니다.', 'info');
   };
 
   /**
    * 날짜별 할 일을 내 일정에 추가하는 핸들러
    */
-  const handleAddDateToMySchedule = (date, dateTodos) => {
-
-    showSnackbar(`${date} 할 일 ${dateTodos.length}개가 내 일정에 추가되었습니다.`);
-  };
-
-  /**
-   * 할 일 다이얼로그 닫기 핸들러
-   */
-  const handleCloseTodoDialog = () => {
-    setTodoDialogOpen(false);
-  };
-
-  /**
-   * 할 일 저장 핸들러
-   */
-  const handleSaveTodo = () => {
-    if (currentTodo.text.trim() === '') {
-      showSnackbar('할 일을 입력해주세요.', 'error');
+  const handleAddDateToMySchedule = (date, dateTodos, type) => {
+    if (type === '전체') {
+      // 모든 타입(회사, 팀, 개인)으로 일정 추가
+      showSnackbar(`${date} 할 일 ${dateTodos.length}개가 모든 일정에 추가되었습니다.`);
+      // 여기에 실제 일정 추가 로직 구현
       return;
     }
-
-    const savePromise = editingTodoId
-      ? updateTodo(meetingId, editingTodoId, currentTodo)
-      : addTodo(meetingId, currentTodo);
-
-    savePromise
-      .then(data => {
-        setTodos(data.todos);
-        setTodoDialogOpen(false);
-        const message = editingTodoId ? '할 일이 수정되었습니다.' : '할 일이 추가되었습니다.';
-        showSnackbar(message);
-      })
-      .catch(err => {
-        const action = editingTodoId ? '수정' : '추가';
-        showSnackbar(`${action} 실패: ${err.message}`, 'error');
-      });
+    
+    // 특정 타입으로 일정 추가
+    showSnackbar(`${date} 할 일 ${dateTodos.length}개가 ${type} 일정으로 추가되었습니다.`);
+    // 여기에 실제 일정 추가 로직 구현
   };
 
   /**
@@ -355,16 +334,6 @@ const TodoScheduleTab = ({ meetingId = 1 }) => {
    */
   const handleCloseSnackbar = () => {
     setSnackbar(prev => ({...prev, open: false}));
-  };
-
-  /**
-   * 현재 할 일 상태 업데이트 핸들러
-   */
-  const handleTodoChange = (field, value) => {
-    setCurrentTodo(prev => ({
-      ...prev,
-      [field]: value
-    }));
   };
 
   // 날짜별로 할 일을 그룹화
@@ -398,7 +367,7 @@ const TodoScheduleTab = ({ meetingId = 1 }) => {
 
   return (
     <Box sx={{ p: 3, bgcolor: 'background.paper' }}>
-      <TodoHeader onAddTodo={handleAddTodo} />
+      <TodoHeader />
       
       <Divider sx={{ mb: 3 }} />
       
@@ -407,16 +376,6 @@ const TodoScheduleTab = ({ meetingId = 1 }) => {
         onEditTodo={handleEditTodo}
         onDeleteTodo={handleDeleteTodo}
         onAddToSchedule={handleAddDateToMySchedule}
-      />
-
-      <TodoDialog
-        open={todoDialogOpen}
-        todo={currentTodo}
-        isEditing={Boolean(editingTodoId)}
-        teamMembers={teamMembers}
-        onClose={handleCloseTodoDialog}
-        onSave={handleSaveTodo}
-        onChange={handleTodoChange}
       />
 
       <Snackbar
@@ -454,19 +413,11 @@ const ErrorView = ({ error }) => (
 /**
  * 할 일 헤더 컴포넌트
  */
-const TodoHeader = ({ onAddTodo }) => (
+const TodoHeader = () => (
   <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 2 }}>
     <Typography variant="h5" component="h2" fontWeight="bold">
       ToDo & 일정
     </Typography>
-    <Button 
-      variant="contained" 
-      startIcon={<AddIcon />}
-      onClick={onAddTodo}
-      sx={{ bgcolor: '#3E1A11', '&:hover': { bgcolor: '#2A120B' } }}
-    >
-      할 일 추가
-    </Button>
   </Box>
 );
 
@@ -499,63 +450,6 @@ const EmptyTodoMessage = () => (
   <Typography sx={{ textAlign: 'center', color: 'text.secondary', py: 4 }}>
     ToDo 항목이 없습니다. 새로운 항목을 추가해 보세요.
   </Typography>
-);
-
-/**
- * 할 일 다이얼로그 컴포넌트
- */
-const TodoDialog = ({ open, todo, isEditing, teamMembers, onClose, onSave, onChange }) => (
-  <Dialog open={open} onClose={onClose} maxWidth="sm" fullWidth>
-    <DialogTitle>{isEditing ? '할 일 수정' : '할 일 추가'}</DialogTitle>
-    <DialogContent>
-      <TextField
-        autoFocus
-        margin="dense"
-        label="할 일"
-        fullWidth
-        variant="outlined"
-        value={todo.text}
-        onChange={(e) => onChange('text', e.target.value)}
-        sx={{ mb: 2 }}
-      />
-      <FormControl fullWidth margin="dense" variant="outlined" sx={{ mb: 2 }}>
-        <InputLabel id="assignee-label">담당자</InputLabel>
-        <Select
-          labelId="assignee-label"
-          id="assignee"
-          value={todo.assignee}
-          onChange={(e) => onChange('assignee', e.target.value)}
-          label="담당자"
-        >
-          <MenuItem value="">
-            <em>담당자 없음</em>
-          </MenuItem>
-          {teamMembers.map((member) => (
-            <MenuItem key={member} value={member}>{member}</MenuItem>
-          ))}
-        </Select>
-      </FormControl>
-      <TextField
-        margin="dense"
-        label="마감일 (YYYY-MM-DD)"
-        fullWidth
-        variant="outlined"
-        value={todo.dueDate}
-        onChange={(e) => onChange('dueDate', e.target.value)}
-        sx={{ mb: 2 }}
-      />
-    </DialogContent>
-    <DialogActions>
-      <Button onClick={onClose}>취소</Button>
-      <Button 
-        onClick={onSave}
-        variant="contained"
-        sx={{ bgcolor: '#3E1A11', '&:hover': { bgcolor: '#2A120B' } }}
-      >
-        저장
-      </Button>
-    </DialogActions>
-  </Dialog>
 );
 
 export default TodoScheduleTab; 

--- a/src/domains/MyPage/MyPage.jsx
+++ b/src/domains/MyPage/MyPage.jsx
@@ -1,5 +1,5 @@
 import React, { useState, useEffect } from 'react';
-import { Box, Container } from '@mui/material';
+import { Box, Container, Paper } from '@mui/material';
 import { useNavigate } from 'react-router-dom';
 import { format, addMonths, subMonths, addDays } from 'date-fns';
 import { myPageStyles } from './css/MyPage.styles';
@@ -31,14 +31,11 @@ const MyPage = () => {
   const [categoryFilter, setCategoryFilter] = useState('전체');
   
   // 카테고리 관리
-  const [categories, setCategories] = useState(['전체', '개인', '미팅', '작업', '면접', '교육']);
-  const [customCategories, setCustomCategories] = useState([]);
+  const [categories] = useState(['전체', '회사', '팀', '개인']);
   
   // 모달 상태
   const [eventModalOpen, setEventModalOpen] = useState(false);
   const [selectedDateEvents, setSelectedDateEvents] = useState([]);
-  const [categoryModalOpen, setCategoryModalOpen] = useState(false);
-  const [newCategory, setNewCategory] = useState('');
   
   // 일정 추가 모달 상태
   const [addEventModalOpen, setAddEventModalOpen] = useState(false);
@@ -62,43 +59,57 @@ const MyPage = () => {
 
   // 일정 데이터 로드
   useEffect(() => {
+    // 저장된 일정 데이터 확인
+    const savedSchedules = localStorage.getItem('schedules');
+    
+    if (savedSchedules) {
+      // 저장된 데이터가 있으면 불러오기
+      try {
+        const parsedSchedules = JSON.parse(savedSchedules);
+        setSchedules(parsedSchedules);
+        setLoading(false);
+      } catch (error) {
+        console.error('저장된 일정 데이터를 불러오는데 실패했습니다:', error);
+        loadDummyData();
+      }
+    } else {
+      // 저장된 데이터가 없으면 더미 데이터 로드
+      loadDummyData();
+    }
+  }, [today]);
+  
+  // 더미 데이터 로드 함수
+  const loadDummyData = () => {
     // 임시 데이터 생성
     const dummySchedules = [
-      { id: 1, date: '2025-01-02', startDate: '2025-01-02', endDate: '2025-01-02', title: '미팅 10:00', category: '미팅', type: '회의' },
-      { id: 2, date: '2025-01-06', startDate: '2025-01-06', endDate: '2025-01-06', title: '미팅 10:00', category: '미팅', type: '회의' },
-      { id: 3, date: '2025-01-06', startDate: '2025-01-06', endDate: '2025-01-06', title: '1차 면접', category: '면접', type: '개인' },
-      { id: 4, date: '2025-01-07', startDate: '2025-01-07', endDate: '2025-01-07', title: '미팅 2:30', category: '미팅', type: '회의' },
-      { id: 5, date: '2025-01-08', startDate: '2025-01-08', endDate: '2025-01-10', title: '2차 서류작성 기간', category: '작업', type: 'Todo' },
-      { id: 6, date: '2025-01-09', startDate: '2025-01-08', endDate: '2025-01-10', title: '2차 서류작성 기간', category: '작업', type: 'Todo' },
-      { id: 7, date: '2025-01-11', startDate: '2025-01-11', endDate: '2025-01-11', title: '미팅 11:00', category: '미팅', type: '회의' },
+      { id: 1, date: '2025-01-02', startDate: '2025-01-02', endDate: '2025-01-02', title: '회사 미팅 10:00', category: '회사', type: '회사' },
+      { id: 2, date: '2025-01-06', startDate: '2025-01-06', endDate: '2025-01-06', title: '회사 미팅 10:00', category: '회사', type: '회사' },
+      { id: 3, date: '2025-01-06', startDate: '2025-01-06', endDate: '2025-01-06', title: '1차 면접', category: '개인', type: '개인' },
+      { id: 4, date: '2025-01-07', startDate: '2025-01-07', endDate: '2025-01-07', title: '팀 미팅 2:30', category: '팀', type: '팀' },
+      { id: 5, date: '2025-01-08', startDate: '2025-01-08', endDate: '2025-01-10', title: '서류작성 기간', category: '회사', type: '회사' },
+      { id: 6, date: '2025-01-09', startDate: '2025-01-08', endDate: '2025-01-10', title: '서류작성 기간', category: '회사', type: '회사' },
+      { id: 7, date: '2025-01-11', startDate: '2025-01-11', endDate: '2025-01-11', title: '팀 미팅 11:00', category: '팀', type: '팀' },
       { id: 8, date: '2025-01-12', startDate: '2025-01-12', endDate: '2025-01-14', title: '가계부 정리', category: '개인', type: '개인' },
-      { id: 9, date: '2025-01-14', startDate: '2025-01-14', endDate: '2025-01-14', title: '마케팅 회의', category: '미팅', type: '회의' },
-      { id: 10, date: '2025-01-17', startDate: '2025-01-17', endDate: '2025-01-17', title: '2차 면접', category: '면접', type: '개인' },
-      { id: 11, date: '2025-01-18', startDate: '2025-01-18', endDate: '2025-01-18', title: '미팅 13:30', category: '미팅', type: '회의' },
-      { id: 12, date: '2025-01-19', startDate: '2025-01-19', endDate: '2025-01-19', title: '2차 면접', category: '면접', type: '개인' },
-      { id: 13, date: '2025-01-22', startDate: '2025-01-22', endDate: '2025-01-22', title: '강의', category: '교육', type: '개인' },
-      { id: 14, date: '2025-01-24', startDate: '2025-01-24', endDate: '2025-01-24', title: '미팅 14:00', category: '미팅', type: '회의' },
-      { id: 15, date: '2025-01-28', startDate: '2025-01-28', endDate: '2025-01-28', title: '미팅 15:00', category: '미팅', type: '회의' },
-      { id: 16, date: format(today, 'yyyy-MM-dd'), startDate: format(today, 'yyyy-MM-dd'), endDate: format(today, 'yyyy-MM-dd'), title: '할 일 작성하기', category: '개인', type: 'Todo' },
-      { id: 17, date: format(addDays(today, 1), 'yyyy-MM-dd'), startDate: format(addDays(today, 1), 'yyyy-MM-dd'), endDate: format(addDays(today, 1), 'yyyy-MM-dd'), title: '이메일 확인', category: '개인', type: 'Todo' },
-      { id: 18, date: format(addDays(today, 2), 'yyyy-MM-dd'), startDate: format(addDays(today, 2), 'yyyy-MM-dd'), endDate: format(addDays(today, 4), 'yyyy-MM-dd'), title: '보고서 제출', category: '개인', type: 'Todo' },
-      { id: 19, date: format(addDays(today, -1), 'yyyy-MM-dd'), startDate: format(addDays(today, -1), 'yyyy-MM-dd'), endDate: format(addDays(today, -1), 'yyyy-MM-dd'), title: '가계부 정리', category: '개인', type: 'Todo' }
+      { id: 9, date: '2025-01-14', startDate: '2025-01-14', endDate: '2025-01-14', title: '마케팅 회의', category: '회사', type: '회사' },
+      { id: 10, date: '2025-01-17', startDate: '2025-01-17', endDate: '2025-01-17', title: '2차 면접', category: '개인', type: '개인' },
+      { id: 11, date: '2025-01-18', startDate: '2025-01-18', endDate: '2025-01-18', title: '팀 미팅 13:30', category: '팀', type: '팀' },
+      { id: 12, date: '2025-01-19', startDate: '2025-01-19', endDate: '2025-01-19', title: '2차 면접', category: '개인', type: '개인' },
+      { id: 13, date: '2025-01-22', startDate: '2025-01-22', endDate: '2025-01-22', title: '강의', category: '개인', type: '개인' },
+      { id: 14, date: '2025-01-24', startDate: '2025-01-24', endDate: '2025-01-24', title: '회사 미팅 14:00', category: '회사', type: '회사' },
+      { id: 15, date: '2025-01-28', startDate: '2025-01-28', endDate: '2025-01-28', title: '회사 미팅 15:00', category: '회사', type: '회사' },
+      { id: 16, date: format(today, 'yyyy-MM-dd'), startDate: format(today, 'yyyy-MM-dd'), endDate: format(today, 'yyyy-MM-dd'), title: '할 일 작성하기', category: '개인', type: '개인' },
+      { id: 17, date: format(addDays(today, 1), 'yyyy-MM-dd'), startDate: format(addDays(today, 1), 'yyyy-MM-dd'), endDate: format(addDays(today, 1), 'yyyy-MM-dd'), title: '이메일 확인', category: '개인', type: '개인' },
+      { id: 18, date: format(addDays(today, 2), 'yyyy-MM-dd'), startDate: format(addDays(today, 2), 'yyyy-MM-dd'), endDate: format(addDays(today, 4), 'yyyy-MM-dd'), title: '보고서 제출', category: '개인', type: '개인' },
+      { id: 19, date: format(addDays(today, -1), 'yyyy-MM-dd'), startDate: format(addDays(today, -1), 'yyyy-MM-dd'), endDate: format(addDays(today, -1), 'yyyy-MM-dd'), title: '가계부 정리', category: '개인', type: '개인' }
     ];
-
-    // 저장된 사용자 정의 카테고리 불러오기
-    const savedCategories = localStorage.getItem('customCategories');
-    if (savedCategories) {
-      const parsedCategories = JSON.parse(savedCategories);
-      setCustomCategories(parsedCategories);
-      setCategories(prev => [...prev.filter(c => c === '전체' || c === '개인' || ['미팅', '작업', '면접', '교육'].includes(c)), ...parsedCategories]);
-    }
-
+    
     // 데이터 로딩 시뮬레이션
     setTimeout(() => {
       setSchedules(dummySchedules);
+      localStorage.setItem('schedules', JSON.stringify(dummySchedules));
       setLoading(false);
     }, 500);
-  }, [today]);
+  };
 
   // 날짜 또는 필터가 변경될 때 일정 필터링
   useEffect(() => {
@@ -131,18 +142,30 @@ const MyPage = () => {
     setAddEventModalOpen(false);
   };
 
-  // 새 일정 입력값 변경 핸들러
+  // 새 일정의 값 변경 핸들러
   const handleNewEventChange = (e) => {
     const { name, value } = e.target;
-    setNewEvent(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setNewEvent(prev => {
+      const updated = {
+        ...prev,
+        [name]: value
+      };
+      
+      // 타입이 변경되면 카테고리도 동일한 값으로 설정
+      if (name === 'type') {
+        updated.category = value;
+      }
+      
+      return updated;
+    });
   };
 
   // 새 일정 저장 핸들러
   const handleSaveNewEvent = () => {
     if (!newEvent.title.trim()) return;
+    
+    // 저장 알림
+    alert('일정이 저장되었습니다: ' + newEvent.title);
     
     // 새 일정 생성
     const newSchedule = {
@@ -152,7 +175,12 @@ const MyPage = () => {
     };
     
     // 일정 목록에 추가
-    setSchedules(prev => [...prev, newSchedule]);
+    setSchedules(prev => {
+      const updated = [...prev, newSchedule];
+      // localStorage에 저장
+      localStorage.setItem('schedules', JSON.stringify(updated));
+      return updated;
+    });
     
     // 모달 닫기
     setAddEventModalOpen(false);
@@ -163,29 +191,20 @@ const MyPage = () => {
     setEventModalOpen(false);
   };
 
-  // 카테고리 모달 닫기 핸들러
-  const handleCloseCategoryModal = () => {
-    setCategoryModalOpen(false);
-    setNewCategory('');
-  };
-
-  // 새 카테고리 추가 핸들러
-  const handleAddCategory = () => {
-    if (newCategory.trim() && !categories.includes(newCategory.trim())) {
-      const updatedCustomCategories = [...customCategories, newCategory.trim()];
-      setCustomCategories(updatedCustomCategories);
-      setCategories(prev => [...prev, newCategory.trim()]);
-      
-      // 로컬 스토리지에 저장
-      localStorage.setItem('customCategories', JSON.stringify(updatedCustomCategories));
-      
-      setNewCategory('');
-    }
-  };
-
   // 개인 일정 삭제 핸들러
   const handleDeletePersonalTodo = (id) => {
-    setSchedules(prev => prev.filter(schedule => schedule.id !== id));
+    // 삭제 전 확인
+    if (!window.confirm('일정을 삭제하시겠습니까?')) {
+      return; // 취소하면 함수 종료
+    }
+    
+    alert('일정이 삭제되었습니다(ID: ' + id + ')');
+    setSchedules(prev => {
+      const updated = prev.filter(schedule => schedule.id !== id);
+      // localStorage에 저장
+      localStorage.setItem('schedules', JSON.stringify(updated));
+      return updated;
+    });
   };
 
   // 일정 수정 모달 열기
@@ -203,20 +222,36 @@ const MyPage = () => {
   // 수정 중인 일정 값 변경 핸들러
   const handleEditEventChange = (e) => {
     const { name, value } = e.target;
-    setEditEvent(prev => ({
-      ...prev,
-      [name]: value
-    }));
+    setEditEvent(prev => {
+      const updated = {
+        ...prev,
+        [name]: value
+      };
+      
+      // 타입이 변경되면 카테고리도 동일한 값으로 설정
+      if (name === 'type') {
+        updated.category = value;
+      }
+      
+      return updated;
+    });
   };
 
   // 일정 수정 저장 핸들러
   const handleSaveEditEvent = () => {
     if (!editEvent || !editEvent.title.trim()) return;
 
+    alert('일정이 수정되었습니다: ' + editEvent.title);
+
     // 수정된 일정으로 업데이트
-    setSchedules(prev => prev.map(item => 
-      item.id === editEvent.id ? { ...editEvent, date: editEvent.startDate } : item
-    ));
+    setSchedules(prev => {
+      const updated = prev.map(item => 
+        item.id === editEvent.id ? { ...editEvent, date: editEvent.startDate } : item
+      );
+      // localStorage에 저장
+      localStorage.setItem('schedules', JSON.stringify(updated));
+      return updated;
+    });
 
     // 모달 닫기
     setEditEventModalOpen(false);
@@ -228,6 +263,10 @@ const MyPage = () => {
     
     // 선택한 날짜 업데이트
     setSelectedDate(clickedDay);
+    
+    // 현재 월을 선택한 날짜의 월로 변경
+    const firstDayOfMonth = new Date(clickedDay.getFullYear(), clickedDay.getMonth(), 1);
+    setCurrentMonth(firstDayOfMonth);
     
     // 필터링된 일정 업데이트
     const dayEvents = filterEventsByDate(schedules, dateStr, categoryFilter);
@@ -272,16 +311,15 @@ const MyPage = () => {
             onDateClick={onDateClick}
             showMoreEvents={showMoreEvents}
             onCategoryFilterChange={setCategoryFilter}
-            setCategoryModalOpen={setCategoryModalOpen}
+            onAddEvent={handleOpenAddEventModal}
           />
         </Paper>
 
         <TodoList 
           schedules={schedules}
-          selectedDate={selectedDate}
-          onAddEvent={handleOpenAddEventModal}
           onEditEvent={handleOpenEditModal}
           onDeleteEvent={handleDeletePersonalTodo}
+          onDateClick={onDateClick}
         />
       </Box>
 
@@ -290,6 +328,7 @@ const MyPage = () => {
         filteredEvents={filteredEvents}
         onAddEvent={handleOpenAddEventModal}
         onEditEvent={handleOpenEditModal}
+        onDateClick={onDateClick}
       />
 
       {/* 모달 컴포넌트들 */}
@@ -298,16 +337,7 @@ const MyPage = () => {
         onClose={handleCloseEventModal}
         events={selectedDateEvents}
         onEditEvent={handleOpenEditModal}
-      />
-
-      <CategoryModal 
-        isOpen={categoryModalOpen}
-        onClose={handleCloseCategoryModal}
-        categories={categories}
-        newCategory={newCategory}
-        onCategoryChange={setNewCategory}
-        onAddCategory={handleAddCategory}
-        onCategoryFilterChange={setCategoryFilter}
+        onDateClick={onDateClick}
       />
 
       <AddEventModal 

--- a/src/domains/MyPage/components/Calendar.jsx
+++ b/src/domains/MyPage/components/Calendar.jsx
@@ -18,38 +18,82 @@ import { format, isSameMonth, isSameDay, startOfMonth, endOfMonth, startOfWeek, 
 import { myPageStyles } from '../css/MyPage.styles';
 import { getCategoryColor, filterEventsByDate } from '../js/utils';
 
+/**
+ * 캘린더 컴포넌트
+ * 월별 일정을 표시하고 일정 관리 기능을 제공
+ */
 const Calendar = ({ 
   currentMonth, 
   selectedDate, 
   schedules, 
   categoryFilter, 
-  categories,
   onPrevMonth, 
   onNextMonth, 
   onDateClick, 
   showMoreEvents,
   onCategoryFilterChange,
-  setCategoryModalOpen
+  onAddEvent
 }) => {
-  // 달력 헤더 렌더링
+  /**
+   * 일정 추가 버튼 클릭 핸들러
+   * 현재 선택된 필터를 기반으로 일정 타입을 설정
+   */
+  const handleAddEventClick = () => {
+    const defaultEvent = {
+      title: '',
+      date: format(selectedDate, 'yyyy-MM-dd'),
+      startDate: format(selectedDate, 'yyyy-MM-dd'),
+      endDate: format(selectedDate, 'yyyy-MM-dd'),
+      category: categoryFilter !== '전체' ? categoryFilter : '개인',
+      type: categoryFilter !== '전체' ? categoryFilter : '개인'
+    };
+    
+    onAddEvent(defaultEvent);
+  };
+
+  /**
+   * 달력 헤더 렌더링
+   * 월 이동 버튼과 일정 추가 버튼을 포함
+   */
   const renderHeader = () => {
     const dateFormat = "yyyy.MM";
     return (
-      <Box sx={myPageStyles.calendarHeader}>
-        <IconButton onClick={onPrevMonth}>
-          <ChevronLeftIcon />
-        </IconButton>
-        <Typography variant="h5" sx={myPageStyles.calendarTitle}>
-          {format(currentMonth, dateFormat)}
-        </Typography>
-        <IconButton onClick={onNextMonth}>
-          <ChevronRightIcon />
-        </IconButton>
+      <Box sx={{ 
+        ...myPageStyles.calendarHeader,
+        display: 'flex',
+        justifyContent: 'space-between',
+        alignItems: 'center',
+        mb: 2
+      }}>
+        <Box sx={{ display: 'flex', alignItems: 'center' }}>
+          <IconButton onClick={onPrevMonth} aria-label="이전 달">
+            <ChevronLeftIcon />
+          </IconButton>
+          <Typography variant="h5" sx={myPageStyles.calendarTitle}>
+            {format(currentMonth, dateFormat)}
+          </Typography>
+          <IconButton onClick={onNextMonth} aria-label="다음 달">
+            <ChevronRightIcon />
+          </IconButton>
+        </Box>
+        <Button
+          variant="outlined"
+          size="small"
+          startIcon={<AddIcon />}
+          onClick={handleAddEventClick}
+          sx={{ minHeight: 0, py: 0.5 }}
+          aria-label="일정 추가"
+        >
+          일정 추가
+        </Button>
       </Box>
     );
   };
 
-  // 날짜 셀 내의 이벤트 렌더링
+  /**
+   * 날짜 셀 내의 이벤트 렌더링
+   * @param {Array} events - 표시할 이벤트 배열
+   */
   const renderDayEvents = (events) => {
     if (events.length === 0) return null;
 
@@ -61,6 +105,7 @@ const Calendar = ({
         maxHeight: '75px',
         overflow: 'hidden'
       }}>
+        {/* 최대 2개의 이벤트만 표시 */}
         {events.slice(0, 2).map((event) => (
           <Box 
             key={event.id} 
@@ -82,6 +127,7 @@ const Calendar = ({
             {event.title}
           </Box>
         ))}
+        {/* 2개 이상의 이벤트가 있는 경우 더보기 표시 */}
         {events.length > 2 && (
           <Box 
             sx={{ 
@@ -105,7 +151,9 @@ const Calendar = ({
     );
   };
 
-  // 달력 렌더링
+  /**
+   * 달력 그리드 렌더링
+   */
   const renderCalendar = () => {
     const monthStart = startOfMonth(currentMonth);
     const monthEnd = endOfMonth(monthStart);
@@ -120,8 +168,9 @@ const Calendar = ({
     const daysOfWeek = ['일', '월', '화', '수', '목', '금', '토'];
 
     // 카테고리 필터
-    const allCategories = ['전체', ...categories.filter(c => c !== '전체')];
+    const categories = ['전체', '회사', '팀', '개인'];
 
+    // 카테고리 필터 행
     const categoryFilters = (
       <TableRow>
         <TableCell colSpan={7} align="center" sx={myPageStyles.filterContainer}>
@@ -130,35 +179,21 @@ const Calendar = ({
               필터
             </Typography>
             <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {allCategories.slice(0, 4).map(cat => (
+              {categories.map(category => (
                 <Button 
-                  key={cat}
-                  variant={categoryFilter === cat ? 'contained' : 'outlined'}
-                  onClick={() => onCategoryFilterChange(cat)}
+                  key={category}
+                  variant={categoryFilter === category ? 'contained' : 'outlined'}
+                  onClick={() => onCategoryFilterChange(category)}
                   sx={{ 
                     minWidth: '80px',
-                    bgcolor: categoryFilter === cat ? '#757575' : 'white',
-                    color: categoryFilter === cat ? 'white' : 'black',
+                    bgcolor: categoryFilter === category ? '#757575' : 'white',
+                    color: categoryFilter === category ? 'white' : 'black',
                     border: '1px solid #ccc'
                   }}
                 >
-                  {cat}
+                  {category}
                 </Button>
               ))}
-              {allCategories.length > 4 && (
-                <Button
-                  variant="outlined"
-                  sx={{ minWidth: 'auto', borderColor: '#ccc' }}
-                  onClick={() => setCategoryModalOpen(true)}
-                >
-                  +{allCategories.length - 4}
-                </Button>
-              )}
-              <Tooltip title="카테고리 추가">
-                <IconButton onClick={() => setCategoryModalOpen(true)} size="small">
-                  <AddIcon fontSize="small" />
-                </IconButton>
-              </Tooltip>
             </Box>
           </Box>
         </TableCell>
@@ -168,13 +203,13 @@ const Calendar = ({
     // 요일 헤더 행
     const dayHeaders = (
       <TableRow>
-        {daysOfWeek.map((day, i) => (
+        {daysOfWeek.map((day, index) => (
           <TableCell 
-            key={i} 
+            key={index} 
             align="center" 
             sx={{ 
               py: 1, 
-              color: i === 0 ? 'red' : i === 6 ? 'blue' : 'inherit',
+              color: index === 0 ? 'red' : index === 6 ? 'blue' : 'inherit',
               fontWeight: 'bold',
               borderBottom: '1px solid #e0e0e0',
               borderTop: '1px solid #e0e0e0'

--- a/src/domains/MyPage/components/DailyEvents.jsx
+++ b/src/domains/MyPage/components/DailyEvents.jsx
@@ -21,7 +21,8 @@ const DailyEvents = ({
   selectedDate, 
   filteredEvents, 
   onAddEvent, 
-  onEditEvent 
+  onEditEvent,
+  onDateClick
 }) => {
   // 일정 추가 버튼 클릭 핸들러
   const handleAddClick = () => {
@@ -33,6 +34,15 @@ const DailyEvents = ({
       category: '개인',
       type: '개인'
     });
+  };
+  
+  // 일정 날짜로 이동 핸들러
+  const handleDateClick = (event) => {
+    // 날짜 객체 생성
+    const eventDate = new Date(event.startDate);
+    
+    // 날짜 클릭 이벤트 실행
+    onDateClick(eventDate);
   };
 
   return (
@@ -55,7 +65,14 @@ const DailyEvents = ({
       {filteredEvents.length > 0 ? (
         <List>
           {filteredEvents.map(event => (
-            <ListItem key={event.id} sx={myPageStyles.eventItem}>
+            <ListItem 
+              key={event.id} 
+              sx={{
+                ...myPageStyles.eventItem,
+                cursor: 'pointer'
+              }}
+              onClick={() => handleDateClick(event)}
+            >
               <ListItemText 
                 primary={event.title}
                 secondary={formatDateRange(event.startDate, event.endDate)}
@@ -76,11 +93,12 @@ const DailyEvents = ({
                     borderRadius: '4px',
                     backgroundColor: getCategoryColor(event.category)
                   }}
+                  onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지
                 />
                 <IconButton 
                   size="small" 
                   onClick={(e) => {
-                    e.stopPropagation();
+                    e.stopPropagation(); // 이벤트 버블링 방지
                     onEditEvent(event);
                   }}
                 >

--- a/src/domains/MyPage/components/Modals.jsx
+++ b/src/domains/MyPage/components/Modals.jsx
@@ -25,8 +25,21 @@ export const EventModal = ({
   isOpen, 
   onClose, 
   events, 
-  onEditEvent 
+  onEditEvent,
+  onDateClick
 }) => {
+  // 일정 날짜로 이동 핸들러
+  const handleDateClick = (event) => {
+    // 날짜 객체 생성
+    const eventDate = new Date(event.startDate);
+    
+    // 날짜 클릭 이벤트 실행
+    onDateClick(eventDate);
+    
+    // 모달 닫기
+    onClose();
+  };
+
   return (
     <Dialog 
       open={isOpen} 
@@ -47,8 +60,10 @@ export const EventModal = ({
               sx={{ 
                 py: 1,
                 borderBottom: '1px solid #f5f5f5',
-                '&:last-child': { borderBottom: 'none' }
+                '&:last-child': { borderBottom: 'none' },
+                cursor: 'pointer'
               }}
+              onClick={() => handleDateClick(event)}
             >
               <ListItemText 
                 primary={event.title} 
@@ -70,6 +85,7 @@ export const EventModal = ({
                     borderRadius: '4px',
                     backgroundColor: getCategoryColor(event.category)
                   }}
+                  onClick={(e) => e.stopPropagation()} // 이벤트 버블링 방지
                 />
                 <IconButton 
                   size="small" 
@@ -211,26 +227,6 @@ export const AddEventModal = ({
             InputLabelProps={{ shrink: true }}
             sx={{ mb: 2 }}
           />
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" gutterBottom>
-              카테고리
-            </Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {categories.filter(c => c !== '전체').map(category => (
-                <Chip
-                  key={category}
-                  label={category}
-                  onClick={() => onChange({ target: { name: 'category', value: category } })}
-                  variant={newEvent.category === category ? "filled" : "outlined"}
-                  sx={{
-                    bgcolor: newEvent.category === category 
-                      ? getCategoryColor(category)
-                      : undefined
-                  }}
-                />
-              ))}
-            </Box>
-          </FormControl>
           <FormControl fullWidth>
             <Typography variant="body2" color="text.secondary" gutterBottom>
               타입
@@ -248,6 +244,18 @@ export const AddEventModal = ({
                 variant={newEvent.type === '개인' ? "filled" : "outlined"}
                 sx={{ bgcolor: newEvent.type === '개인' ? getCategoryColor('개인') : undefined }}
               />
+              <Chip
+                label="회사"
+                onClick={() => onChange({ target: { name: 'type', value: '회사' } })}
+                variant={newEvent.type === '회사' ? "filled" : "outlined"}
+                sx={{ bgcolor: newEvent.type === '회사' ? getCategoryColor('회사') : undefined }}
+              />
+              <Chip
+                label="팀"
+                onClick={() => onChange({ target: { name: 'type', value: '팀' } })}
+                variant={newEvent.type === '팀' ? "filled" : "outlined"}
+                sx={{ bgcolor: newEvent.type === '팀' ? getCategoryColor('팀') : undefined }}
+              />
             </Box>
           </FormControl>
         </Box>
@@ -255,7 +263,7 @@ export const AddEventModal = ({
       <DialogActions>
         <Button onClick={onClose}>취소</Button>
         <Button 
-          onClick={onSave}
+          onClick={() => onSave()}
           disabled={!newEvent.title.trim()}
           variant="contained"
           sx={{ bgcolor: '#757575' }}
@@ -320,26 +328,6 @@ export const EditEventModal = ({
             InputLabelProps={{ shrink: true }}
             sx={{ mb: 2 }}
           />
-          <FormControl fullWidth sx={{ mb: 2 }}>
-            <Typography variant="body2" color="text.secondary" gutterBottom>
-              카테고리
-            </Typography>
-            <Box sx={{ display: 'flex', flexWrap: 'wrap', gap: 1 }}>
-              {categories.filter(c => c !== '전체').map(category => (
-                <Chip
-                  key={category}
-                  label={category}
-                  onClick={() => onChange({ target: { name: 'category', value: category } })}
-                  variant={editEvent.category === category ? "filled" : "outlined"}
-                  sx={{
-                    bgcolor: editEvent.category === category 
-                      ? getCategoryColor(category)
-                      : undefined
-                  }}
-                />
-              ))}
-            </Box>
-          </FormControl>
           <FormControl fullWidth>
             <Typography variant="body2" color="text.secondary" gutterBottom>
               타입
@@ -357,6 +345,18 @@ export const EditEventModal = ({
                 variant={editEvent.type === '개인' ? "filled" : "outlined"}
                 sx={{ bgcolor: editEvent.type === '개인' ? getCategoryColor('개인') : undefined }}
               />
+              <Chip
+                label="회사"
+                onClick={() => onChange({ target: { name: 'type', value: '회사' } })}
+                variant={editEvent.type === '회사' ? "filled" : "outlined"}
+                sx={{ bgcolor: editEvent.type === '회사' ? getCategoryColor('회사') : undefined }}
+              />
+              <Chip
+                label="팀"
+                onClick={() => onChange({ target: { name: 'type', value: '팀' } })}
+                variant={editEvent.type === '팀' ? "filled" : "outlined"}
+                sx={{ bgcolor: editEvent.type === '팀' ? getCategoryColor('팀') : undefined }}
+              />
             </Box>
           </FormControl>
         </Box>
@@ -364,7 +364,7 @@ export const EditEventModal = ({
       <DialogActions>
         <Button onClick={onClose}>취소</Button>
         <Button 
-          onClick={onSave}
+          onClick={() => onSave()}
           disabled={!editEvent.title.trim()}
           variant="contained"
           sx={{ bgcolor: '#757575' }}

--- a/src/domains/MyPage/components/TodoList.jsx
+++ b/src/domains/MyPage/components/TodoList.jsx
@@ -3,7 +3,6 @@ import {
   Box, 
   Typography, 
   Paper, 
-  Button, 
   Divider, 
   List, 
   ListItem, 
@@ -11,70 +10,60 @@ import {
   Checkbox,
   IconButton
 } from '@mui/material';
-import AddIcon from '@mui/icons-material/Add';
 import EditIcon from '@mui/icons-material/Edit';
 import DeleteIcon from '@mui/icons-material/Delete';
-import { format } from 'date-fns';
 import { myPageStyles } from '../css/MyPage.styles';
-import { formatDateRange } from '../js/utils';
 
+/**
+ * 개인 할일 목록을 표시하는 컴포넌트
+ */
 const TodoList = ({ 
   schedules, 
-  selectedDate, 
-  onAddEvent, 
   onEditEvent, 
-  onDeleteEvent 
+  onDeleteEvent,
+  onDateClick
 }) => {
-  // 할일 추가 버튼 클릭 핸들러
-  const handleAddClick = () => {
-    onAddEvent({
-      title: '',
-      date: format(selectedDate, 'yyyy-MM-dd'),
-      startDate: format(selectedDate, 'yyyy-MM-dd'),
-      endDate: format(selectedDate, 'yyyy-MM-dd'),
-      category: '개인',
-      type: '개인'
-    });
+  /**
+   * 할일 항목 클릭 시 해당 날짜로 이동하는 핸들러
+   * @param {Object} todo - 할일 객체
+   */
+  const handleTodoClick = (todo) => {
+    const todoDate = new Date(todo.startDate);
+    onDateClick(todoDate);
   };
 
-  // 할일 목록 필터링 (개인 카테고리만)
-  const personalEvents = schedules
-    .filter(event => event.category === '개인')
+  // 개인 카테고리 일정만 필터링하고 날짜순으로 정렬
+  const personalTodos = schedules
+    .filter(event => event.type === '개인')
     .sort((a, b) => new Date(a.startDate) - new Date(b.startDate));
 
   return (
     <Paper sx={myPageStyles.todoPostit}>
-      <Box sx={{ display: 'flex', justifyContent: 'space-between', alignItems: 'center', mb: 1 }}>
+      <Box sx={{ display: 'flex', alignItems: 'center', mb: 1 }}>
         <Typography variant="h6" sx={myPageStyles.postitTitle}>
           내 할 일
         </Typography>
-        <Button
-          variant="outlined"
-          size="small"
-          startIcon={<AddIcon />}
-          onClick={handleAddClick}
-          sx={{ minHeight: 0, py: 0.5 }}
-        >
-          일정 추가
-        </Button>
       </Box>
       <Divider sx={{ mb: 2 }} />
       
       <List>
-        {personalEvents.map((todo) => (
+        {personalTodos.map((todo) => (
           <ListItem
             key={todo.id}
-            sx={myPageStyles.todoItem}
+            sx={{
+              ...myPageStyles.todoItem,
+              cursor: 'pointer'
+            }}
+            onClick={() => handleTodoClick(todo)}
           >
             <Checkbox
               sx={myPageStyles.todoCheckbox}
+              onClick={(e) => e.stopPropagation()}
             />
             <ListItemText
               primary={
                 <Box component="span">
-                  {todo.title} <Typography component="span" color="text.secondary" sx={{ fontSize: '0.85em' }}>
-                    ({formatDateRange(todo.startDate, todo.endDate)})
-                  </Typography>
+                  {todo.title}
                 </Box>
               }
               sx={{
@@ -84,27 +73,34 @@ const TodoList = ({
                   whiteSpace: 'nowrap'
                 }
               }}
-              onClick={() => onEditEvent(todo)}
             />
             <Box sx={{ display: 'flex', gap: 0.5 }}>
               <IconButton 
                 size="small" 
-                onClick={() => onEditEvent(todo)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onEditEvent(todo);
+                }}
                 sx={{ color: '#666' }}
+                aria-label="할일 수정"
               >
                 <EditIcon fontSize="small" />
               </IconButton>
               <IconButton 
                 size="small" 
-                onClick={() => onDeleteEvent(todo.id)}
+                onClick={(e) => {
+                  e.stopPropagation();
+                  onDeleteEvent(todo.id);
+                }}
                 sx={{ color: '#666' }}
+                aria-label="할일 삭제"
               >
                 <DeleteIcon fontSize="small" />
               </IconButton>
             </Box>
           </ListItem>
         ))}
-        {personalEvents.length === 0 && (
+        {personalTodos.length === 0 && (
           <Box sx={{ textAlign: 'center', p: 2 }}>
             <Typography color="text.secondary">
               개인 일정이 없습니다.

--- a/src/domains/MyPage/css/MyPage.styles.js
+++ b/src/domains/MyPage/css/MyPage.styles.js
@@ -33,9 +33,11 @@ export const myPageStyles = {
   },
   calendarHeader: {
     display: 'flex',
-    justifyContent: 'center',
+    justifyContent: 'space-between',
     alignItems: 'center',
-    mb: 2
+    mb: 2,
+    px: 1,
+    py: 1
   },
   calendarTitle: {
     fontWeight: 'bold',

--- a/src/domains/MyPage/js/utils.js
+++ b/src/domains/MyPage/js/utils.js
@@ -1,12 +1,12 @@
-import { format } from 'date-fns';
-
 // 카테고리별 색상 매핑
 export const CATEGORY_COLORS = {
   '미팅': '#ae7ddd',  
   '작업': '#ffdd95',  
   '면접': '#ff9e9e',  
   '교육': '#a1e6bc',  
-  '개인': '#87ceeb',  
+  '개인': '#87ceeb',
+  '회사': '#ff9e6b',
+  '팀': '#70b15c',  // 팀 색상을 초록색 계열로 변경
   'default': '#cccccc' 
 };
 
@@ -23,13 +23,16 @@ export const formatDateRange = (startDate, endDate) => {
 // 날짜 범위 내 일정 필터링 유틸리티 함수
 export const filterEventsByDate = (events, dateStr, categoryFilter) => {
   // 날짜가 startDate와 endDate 사이에 있는 일정 필터링
+  const targetDate = new Date(dateStr);
   let filtered = events.filter(event => {
-    return dateStr >= event.startDate && dateStr <= event.endDate;
+    const startDate = new Date(event.startDate);
+    const endDate = new Date(event.endDate);
+    return targetDate >= startDate && targetDate <= endDate;
   });
   
   // 카테고리 필터 적용
   if (categoryFilter !== '전체') {
-    filtered = filtered.filter(event => event.category === categoryFilter);
+    filtered = filtered.filter(event => event.category === categoryFilter || event.type === categoryFilter);
   }
   
   return filtered;


### PR DESCRIPTION
## 변경 내용
- 일정 추가 버튼을 TodoList에서 Calendar로 이동
- 현재 선택된 필터에 따라 새 일정 타입 자동 설정
- 코드 가독성 및 유지보수성 개선

## 주요 변경 파일
- TodoList.jsx: 일정 추가 버튼 제거 및 코드 정리
- Calendar.jsx: 일정 추가 버튼 추가 및 기능 구현
- MyPage.jsx: props 전달 구조 변경
- MyPage.styles.js: 캘린더 헤더 스타일 개선

## 테스트 항목
- 캘린더에서 일정 추가 버튼 클릭 시 모달 표시 여부
- 필터에 따른 일정 타입 자동 설정 기능