### PR TITLE
fix: SetToListModal 체크박스 인덱스 처리 로직 수정 및 MyPage 불필요한 import 제거

### DIFF
--- a/src/domains/MeetingDetailsPage/components/SetToListModal.jsx
+++ b/src/domains/MeetingDetailsPage/components/SetToListModal.jsx
@@ -95,27 +95,23 @@ const SetToListModal = ({ setToList, onClose }) => {
 
       {/* 체크박스 리스트 */}
       <List>
-        {filteredPeople.map((person, idx) => {
-          // peopleList의 실제 인덱스 찾기
-          const realIdx = peopleList.findIndex((p) => p === person);
-          return (
-            <ListItem key={person.name} disablePadding>
-              <ListItemText
-                primary={
-                  person.position
-                    ? `${person.name} ${person.position}`
-                    : person.name
-                }
+        {filteredPeople.map((person) => (
+          <ListItem key={person.id} disablePadding>
+            <ListItemText
+              primary={
+                person.position
+                  ? `${person.name} ${person.position}`
+                  : person.name
+              }
+            />
+            <ListItemSecondaryAction>
+              <Checkbox
+                checked={checkedList[person.id - 1] || false}
+                onChange={() => handleToggle(person.id - 1)}
               />
-              <ListItemSecondaryAction>
-                <Checkbox
-                  checked={checkedList[realIdx] || false}
-                  onChange={() => handleToggle(realIdx)}
-                />
-              </ListItemSecondaryAction>
-            </ListItem>
-          );
-        })}
+            </ListItemSecondaryAction>
+          </ListItem>
+        ))}
       </List>
       <Button
         variant="contained"

--- a/src/domains/MyPage/MyPage.jsx
+++ b/src/domains/MyPage/MyPage.jsx
@@ -1,6 +1,5 @@
 import React, { useState, useEffect } from "react";
 import { Box, Container, Paper } from "@mui/material";
-import { useNavigate } from "react-router-dom";
 import { format, addMonths, subMonths, addDays } from "date-fns";
 import { myPageStyles } from "./css/MyPage.styles";
 
@@ -10,7 +9,6 @@ import TodoList from "./components/TodoList";
 import DailyEvents from "./components/DailyEvents";
 import {
   EventModal,
-  CategoryModal,
   AddEventModal,
   EditEventModal,
 } from "./components/Modals";
@@ -59,8 +57,6 @@ const MyPage = () => {
 
   // 선택된 날짜의 일정
   const [filteredEvents, setFilteredEvents] = useState([]);
-
-  const navigate = useNavigate();
 
   // 일정 데이터 로드
   useEffect(() => {


### PR DESCRIPTION
## 변경사항
1. SetToListModal 컴포넌트의 체크박스 인덱스 처리 로직 수정
   - person.id를 기준으로 체크박스 상태 관리하도록 변경
   - 불필요한 findIndex 로직 제거

2. MyPage 컴포넌트의 불필요한 import 제거
   - 사용하지 않는 CategoryModal import 제거
   - 사용하지 않는 useNavigate import 제거

## 테스트 방법
1. SetToListModal에서 체크박스 선택/해제가 정상적으로 동작하는지 확인
2. 필터링 후에도 체크박스 상태가 유지되는지 확인
3. MyPage 컴포넌트가 정상적으로 렌더링되는지 확인